### PR TITLE
Fix #3 and support real URLs on Surge

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,6 @@ The domain name that your project builds can update in the `CNAME` file.
 Make sure your domain is `<something>.surge.sh`.
 For more info look at the [Surge Docs](http://surge.sh/help/remembering-a-domain)
 
-## Hash location
-
-I recommend using the `hash` [location](http://emberjs.com/api/classes/Ember.Location.html#toc_hashlocation)
-for your urls because surge.sh is setup for static sites will try and load a file for `kiwiupover.com/file`.
 
 ## Contributing
 

--- a/blueprints/ember-cli-surge/files/public/200.html
+++ b/blueprints/ember-cli-surge/files/public/200.html
@@ -1,1 +1,0 @@
-<p>Hooking up the Ember Goodness.</p>

--- a/blueprints/surge/files/public/200.html
+++ b/blueprints/surge/files/public/200.html
@@ -1,1 +1,0 @@
-<p>Hooking up the Ember Goodness.</p>

--- a/lib/commands/surge.js
+++ b/lib/commands/surge.js
@@ -96,6 +96,9 @@ module.exports = {
     var surgeArgs;
 
     return this.triggerBuild(options).then( function () {
+      // copy index.html to 200.html to support real URLs, see https://surge.sh/help/adding-a-200-page-for-client-side-routing
+      fs.writeFileSync(self.projectPath + '/dist/200.html', fs.readFileSync(self.projectPath + '/dist/index.html'));
+
       domainName = self.cnameFile( self.projectPath );
       surgeArgs = self.buildSurgeArgs(options, domainName);
 

--- a/lib/commands/surge.js
+++ b/lib/commands/surge.js
@@ -69,8 +69,12 @@ module.exports = {
     return surgeOptArgs;
   },
 
-  cnameFile: function( file ){
+  cnameFile: function( file ) {
     return fs.readFileSync( file + '/CNAME', 'utf8');
+  },
+
+  copyIndex: function (path) {
+    return fs.writeFileSync(path + '/dist/200.html', fs.readFileSync(path + '/dist/index.html'));
   },
 
   triggerBuild: function(commandOptions) {
@@ -97,7 +101,7 @@ module.exports = {
 
     return this.triggerBuild(options).then( function () {
       // copy index.html to 200.html to support real URLs, see https://surge.sh/help/adding-a-200-page-for-client-side-routing
-      fs.writeFileSync(self.projectPath + '/dist/200.html', fs.readFileSync(self.projectPath + '/dist/index.html'));
+      self.copyIndex(self.projectPath);
 
       domainName = self.cnameFile( self.projectPath );
       surgeArgs = self.buildSurgeArgs(options, domainName);

--- a/tests/unit/commands/surge-nodetest.js
+++ b/tests/unit/commands/surge-nodetest.js
@@ -18,6 +18,7 @@ describe('surge command', function() {
   var CommandUnderTest;
   var buildTaskCalled;
   var buildTaskReceivedProject;
+  var copyTaskCalled;
 
   before(function() {
     CommandUnderTest = Command.extend(DivshotCommandBase);
@@ -25,6 +26,7 @@ describe('surge command', function() {
 
   beforeEach(function() {
     buildTaskCalled = false;
+    copyTaskCalled = false;
     ui = new MockUI();
     analytics = new MockAnalytics();
     tasks = {
@@ -55,8 +57,13 @@ describe('surge command', function() {
       tasks: tasks,
       settings: {},
 
-      cnameFile: function(){
+      cnameFile: function() {
         return 'surge-app.surge.sh';
+      },
+
+      copyIndex: function() {
+        copyTaskCalled = true;
+        return true;
       },
 
       runCommand: function(command, args) {
@@ -75,8 +82,13 @@ describe('surge command', function() {
       tasks: tasks,
       settings: {},
 
-      cnameFile: function(){
+      cnameFile: function() {
         return 'surge-app.surge.sh';
+      },
+
+      copyIndex: function() {
+        copyTaskCalled = true;
+        return true;
       },
 
       runCommand: function(command, args) {
@@ -94,8 +106,13 @@ describe('surge command', function() {
       tasks: tasks,
       settings: {},
 
-      cnameFile: function(){
+      cnameFile: function() {
         return 'surge-app.surge.sh';
+      },
+
+      copyIndex: function() {
+        copyTaskCalled = true;
+        return true;
       },
 
       runCommand: function(command, args) {
@@ -103,6 +120,8 @@ describe('surge command', function() {
             'expected build task to be called');
         assert(buildTaskReceivedProject,
             'expected build task to receive project');
+        assert(copyTaskCalled,
+            'expected copy task to be called');
       }
     }).validateAndRun();
   });


### PR DESCRIPTION
Remove static 200.html from blueprints, instead copy `index.html` to `200.html` after build.
More info: https://surge.sh/help/adding-a-200-page-for-client-side-routing