### PR TITLE
Adds ~ instead of ^ for Surge

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "ember-cli-babel": "^5.0.0",
     "rsvp": "~3.0.9",
-    "surge": "^0.12.0"
+    "surge": "~0.14.3"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
Improves #7 by defaulting to the most recent, non-major change to the Surge CLI.

We didn’t add `--token` and proper environment variable support until v0.13.0.