### PR TITLE
Fixes surge version number

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "ember-cli-babel": "^5.0.0",
     "rsvp": "~3.0.9",
-    "surge": "~0.14.3"
+    "surge": "^0.17.3"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
Right now the surge version included is out of date, this gets things back in working order.