### PR TITLE
Add new domain

### DIFF
--- a/lib/commands/surge.js
+++ b/lib/commands/surge.js
@@ -33,7 +33,7 @@ module.exports = Command.extend({
     { name: 'whoami', type: String, aliases: ['w'], default: false, description: 'Check who you are logged in as.' },
     { name: 'list', type: String, aliases: ['ls'], default: false, description: 'List all the projects you’ve published on Surge (surge.sh)' },
     { name: 'token', type: String, aliases: ['t'], default: false, description: 'Get surge.sh authentication token, great for Continuous Integration (CI)' },
-    { name: 'new-domain', type: String, aliases: ['d'], default: false, description: 'Surge.sh will provide a unique domain or you can enter your own.' },
+    { name: 'new-domain', type: String, aliases: ['d'], default: false, description: 'Add your own domain name ie: `--new-domain="kiwis.surge.sh"` \n                                     or (surge.sh) will generate a domain when no argumentment is passed in ie:`--new-domain`' },
     { name: 'logout', type: String, default: false, description: 'Log out of your account at Surge (surge.sh)' },
     { name: 'publish', type: String, aliases: ['p'], default: true, description: 'Publishes a project to the web using Surge.' },
     { name: 'environment', type: String, aliases: ['e'], default: 'production', description: 'The ember env you want deployed default (production).' }
@@ -87,21 +87,21 @@ module.exports = Command.extend({
     return buildTask.run(commandOptions);
   },
 
-  buildAndPublish: function(options, args, newDomain) {
+  buildAndPublish: function(options, args, provideNewDomain) {
     var self = this;
-    var domainName;
     args.push('--project', 'dist');
 
-    return this.triggerBuild(options).then( function () {
+    return this.triggerBuild(options).then(function() {
 
       // copy index.html to 200.html to support real URLs,
       // see https://surge.sh/help/adding-a-200-page-for-client-side-routing
       self.copyIndex( self.projectPath );
 
-      domainName = self.cnameFile( self.projectPath );
+      var domainName = self.cnameFile(self.projectPath);
+      var domain = options.newDomain || domainName;
 
-      if(domainName && !newDomain) {
-        args.push('--domain', domainName);
+      if(domain && !provideNewDomain) {
+        args.push('--domain', domain);
       }
 
       return self.runCommand('publish', args);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli-surge",
-  "version": "1.1.11",
+  "version": "1.1.12",
   "description": "the EmberJS addon to use surge.sh for deployments.",
   "directories": {
     "test": "tests"

--- a/tests/unit/commands/surge-nodetest.js
+++ b/tests/unit/commands/surge-nodetest.js
@@ -150,6 +150,21 @@ describe('Surge commands', function() {
     });
   });
 
+  it('Build and deploy to the user provided domain', function(done){
+    var args = [];
+
+    tasks.Build.prototype.run;
+
+    command.validateAndRun(['ember', 'surge', '--new-domain=daves-domain.surge.sh']).then(function(){
+      surgeCommand = command.runCommand.calledWith[0][0];
+      expectedArgs = command.runCommand.calledWith[0][1];
+
+      expect(surgeCommand).to.equal('publish');
+      expect(expectedArgs).to.deep.equal(['--project', 'dist', '--domain', 'daves-domain.surge.sh']);
+      done();
+    });
+  });
+
   var surgeCommands = ['login', 'logout', 'whoami', 'list', 'token'];
 
   surgeCommands.forEach(function(surgeCommand){


### PR DESCRIPTION
Users can now pass in a new domain to the surge command and that will be the domain that surge.sh with push you code too. 

IE: 
```sh 
ember surge --new-domain='kiwis-are-good-people.surge.sh'
```

Closes #40 